### PR TITLE
fix destroyAll() with no WHERE filter

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -620,7 +620,7 @@ BridgeToRedis.prototype.destroyAll = function destroyAll(model, where, callback)
         callback = where;
         where = undefined;
     }
-    if(where) {
+    if(where && Object.keys(where).length) {
         this.all(model, {where: where}, function(err, results) {
             if(err || !results) {
                 callback && callback(err, results);


### PR DESCRIPTION
My application is doing

    app.models.Something.destroyAll(done);

as the beforeEach hook in my mocha tests. This works perfectly fine for MySQL and MongoDB, but fails with Redis. Apparently, the "do we have a where filter?" check incorrectly sees an empty object as a valid filter.

This PR applies the same logic as is already implemented in ``count()`` (see a few lines below in the code) to ``destroyAll()``.