### PR TITLE
change the test script for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "make test"
+    "test": "mocha --growl"
   },
   "dependencies": {
     "async": "^0.9.0",


### PR DESCRIPTION
In order to generate the mocha test report, our automation script will invoke "npm test" and it needs to detect that mocha is a command in the test script so we move the command in the test case in the Makefile to here.