### PR TITLE
handle ObjectId from mongodb

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -22,7 +22,7 @@ exports.initialize = function initializeSchema(dataSource, callback) {
 
     var params = [];
     if (dataSource.settings.port) {
-      params.push(dataSource.settings.port); 
+      params.push(dataSource.settings.port);
     }
     if (dataSource.settings.host) {
       params.push(dataSource.settings.host);
@@ -193,6 +193,10 @@ BridgeToRedis.prototype.forDb = function (model, data) {
         if (typeof data[i] === 'undefined') {
             delete data[i];
             continue;
+        }
+        // it's a mongodb objectId
+        if (data[i]._bsontype === "ObjectID") {
+            data[i] = data[i].toString();
         }
         if (!p[i]){
           data[i] = JSON.stringify(data[i]);


### PR DESCRIPTION
When using as datasource for User mongodb and for accessToken redis then there is an issue when we want to store the accessToken and we got the principalId as ObjectId from mongodb directly. The id is then stored with additional quotes.