### PR TITLE
Made redis return empty array and error when no results found

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -605,6 +605,14 @@ BridgeToRedis.prototype.all = function all(model, filter, callback) {
                 return redis.fromDb(model, r, filter.fields);
             });
 
+            // check if there were no objects returned and modifies
+            // the results as neccessary to generate a 404 message
+            if ( objs.length == 1 && objs[0] == null ) {
+                objs = [];
+                err = new Error("No objects found")
+                err.status = 404
+            }
+
             if (filter && filter.include) {
                 redis._models[model].model.include(objs, filter.include, callback);
             } else {


### PR DESCRIPTION
Previously when accessing a model stored in redis via the API, if the model didn't exist, an empty object would be returned.  When trying to call `Model.findById` the callback would give an undefined error, and an empty or null object.  This behaviour is not idiomatic nodejs and breaks the REST behaviour of returning 404 when an object doesn't exist.